### PR TITLE
Fix WebpackError that blocks build on Netlify

### DIFF
--- a/template/web/src/components/portableText.js
+++ b/template/web/src/components/portableText.js
@@ -6,7 +6,7 @@ import { Figure } from "./Figure";
 const components = {
   types: {
     /* eslint-disable-next-line react/display-name */
-    authorReference: ({ node }) => <span>{node.author.name}</span>,
+    authorReference: ({ node }) => <span>{node?.author?.name}</span>,
     mainImage: Figure,
   },
 };


### PR DESCRIPTION
In trying to build the stock project, I got the following error from Netlify “WebpackError: TypeError: Cannot read properties of undefined (reading ‘author’  )” - fix due to a kind person on the Sanity Slack channel.